### PR TITLE
Global install fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-/node_modules/
+node_modules
+.DS_Store
 npm-debug.log
-
-// Ignore files created by our example app
 example.html
 example.csv
 xunit.xml
+*.iml

--- a/lib/html.js
+++ b/lib/html.js
@@ -11,12 +11,13 @@
 'use strict';
 
 var fs = require('fs'),
+    path = require('path'),
     utils = require('./tenon-utils'),
     hogan = require('hogan.js');
 
 var HTML = function(tenonJson, callback) {
 
-    fs.readFile('./lib/templates/html.tmpl', function (err, file) {
+    fs.readFile(path.join(__dirname, 'templates', 'html.tmpl'), function (err, file) {
         if (err) {
             return callback(err, null);
         }

--- a/lib/tenon-utils.js
+++ b/lib/tenon-utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Convert a string value to a boolean
-String.prototype.toBool = function(val) {
+var toBool = function(val) {
     return val !== '0';
 };
 
@@ -13,11 +13,11 @@ String.prototype.toBool = function(val) {
  */
 module.exports.updateBooleanValues = function(tenonJson) {
     if (typeof tenonJson.request.fragment !== 'boolean') {
-        tenonJson.request.fragment = tenonJson.request.fragment.toBool();
+        tenonJson.request.fragment = toBool(tenonJson.request.fragment);
     }
 
     if (typeof tenonJson.request.store !== 'boolean') {
-        tenonJson.request.store = tenonJson.request.store.toBool();
+        tenonJson.request.store = toBool(tenonJson.request.store);
     }
     return tenonJson;
 };

--- a/lib/xunit.js
+++ b/lib/xunit.js
@@ -11,12 +11,13 @@
 'use strict';
 
 var fs = require('fs'),
+    path = require('path'),
     utils = require('./tenon-utils'),
     hogan = require('hogan.js');
 
 var XUnit = function(tenonJson, callback) {
 
-    fs.readFile('./lib/templates/xunit.tmpl', function (err, file) {
+    fs.readFile(path.join(__dirname, 'templates', 'xunit.tmpl'), function (err, file) {
         if (err) {
             return callback(err, null);
         }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "files": [
+    "index.js",
     "lib"
   ],
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "license": "MIT",
   "files": [
     "index.js",
-    "lib"
+    "lib",
+    "lib/templates"
   ],
   "keywords": [
     "tenon",


### PR DESCRIPTION
Fixes include:
- making it work when installed in another library, using path from current folder to locate templates
- toBool function removed from String prototype and used directly
- added templates and lib to package files, otherwise not present when npm installed